### PR TITLE
Add facebook messenger section to index page

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,9 +1,30 @@
+# The app environment (development|production)
 APPLICATION_ENV
-ACL_CAN_WRITE='{}'
+
+# An array of token, which have write access
+ACL_CAN_WRITE='[]'
+
+# C.f. https://blackfire.io/docs/introduction
 BLACKFIRE_SERVER_ID
 BLACKFIRE_SERVER_TOKEN
+
+# The database url
 DATABASE_URL
+
+# Facebook integration details
+FACEBOOK_APP_ID
+FACEBOOK_APP_PAGE_ID
+FACEBOOK_APP_SECRET
+FACEBOOK_JSSDK_VERSION
+FACEBOOK_PAGE_ACCESS_TOKEN
+FACEBOOK_VERIFICATION_TOKEN
+
+# Logz.io configuration - c.f. http://logz.io/
 LOGZIO_API_KEY
-MONGODB_URI
+
+# Papertrail configuration - c.f. http://help.papertrailapp.com/
 PAPERTRAIL_API_TOKEN
-SLACK_AUTHSLACK_AUTH='{"clientId":"","clientSecret":"","verificationToken":""}'
+
+# Slakc integration details
+SLACK_AUTH={"clientId":"","clientSecret":""}
+SLACK_VERIFICATION_TOKEN

--- a/assets/views/index.html
+++ b/assets/views/index.html
@@ -45,15 +45,10 @@
         <p><small><b>Help:</b> From within slack, you can just type <code class="quoted red">/chuck help</code> for some extra information on how to use the app.</small></p>
     </section>
     <section id="facebook_messenger">
-        <h3><img alt="Facebook Messenger" src="" /></h3>
-        <p>The Chuck Norris app is also on Facebook Messenger. Click the Message Us button below to start a conversation.</p>
+        <h3><img alt="Facebook Messenger" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAW0AAAATCAYAAABbXlwnAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4AoXChsA+U+I6QAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAAZ7SURBVHja7ZxfaFNXHMc/iWllVUz6IkyorVj2oA7ciyAONvfiHHaMYW2p2+OcvmwOHyZ7HHvYYA8bg7kxUEZnrXawQYvg2MDCpGink/lnImnTGi1auzW50aRNau9eknm95v4/5+Ym6Q8utLnnfvP7nvP7/u7vnHtuQgDpnnYVl5Yi39zadytV7pxT3GhfPGTVxq2vRn7K4O4GU4Vrsb74JpHcK4Fphmc0vqVrzGLJqzn1S99+UaWj+UR8KIix4xeeaL5OxkTfttb4OtFbKN3TrhY7SC0CO3YwkSl0bx6cPFnu3I41Teqpl9fYwrmemmfr6aRl4naCaeanDO5eMa0SlxvufmHa4a4VY7kgNoslLwnbq18Al2ZyP27/5U6nrNgRHd8i8UTzdTImRuNRa3zt6i3yOKET0vxt21oGxlAKaj/wEBjSn+9/aU0HMOgA8ipgWh26wDTzUwZ315jPDyRngWYgJYq7z5hW3LXnn7IPL943jCWP5skvgOF7ud3Ap8BhmbpxMx5mfScQTzRfKbEiMD/4zdeW3iKarF8W5GRCYd/ItBXmE+K1Mw2I9sW1lRAAG2LLSfe0bwRU/XQ03dOuqqjfhgi9Ww7v4swcveOK4ffNLaiUSzKiuVthGnEvWbJzPYlMYYe+ejfjDnDwwmM/v9iyuiKYdrh7nXZ6qLYdC8ULptPYKVVibvvmo4v3uZaaf2p2IQpPUp4QNiZOc45X/2TwtZsXIjb75DjwlgQtGd51uoenBoEO7V3ULMHEM3mOxZVR4KjJ9+Vc+Og793IVhBl3gGNxBeBAMcEeqRSmF/tpMsNUdoEaMkex4+Vm1juuoBTUQ8AVWXgV1IoM3fk+vqLygmXS7lq3iq51q/YCe92sl/pZ+QA3gW9EgVUZdzTcjwQV02wt770L0ygFdQC447eSW5oiJLML3O18rg0WAxc7Niu7o0ZLYLLxZGilNCaSZl6qF/9k8LWbF8JeyRfXWmLUodUzd5F2PTVPtC+OUlAB9gF/+u3D1TfaANqeaVhMBDh2jhcrMaMjVWE8oXxLY1KNWpaZGyJeAYzWNuvBZHAvPsCoq37cejoJcA2LB9Cy7crrrYmgxo7oyk7WLFK0VkSPidGSkWgti8bT5gXPlfb756fZ+evtfmCXk+veOXf3/6OarbjOtEswbDPid08E3TZV2oG1KxsqFjt23lEwsxiNs5c7WrtK/4vGq5RWRI9JtC8eMnogKVrLIvB0s9BmYMiy0h5T8gzfyxqe759QmHvEfuCyE2dOTT4AeBvgu230VmOWkVEV1+PMZeS1llK1XTdWLna0+3gtqs+yyUz/YFg0Xg3NIG31S4D4PjELtUzaf/wzxwejM3HgN5NmvUDWhTM/aK4PnLnd8mfjbq+drkkVSzVYcaunKvONyCqKHcsKee2Khgmg1UGCEonnm1aup+bZEFtOPeUGA21sTJGP6V+usbLzwH7q03zf8levVpySd9fQLMO3LX9+4Pmtla2nk67eRKyB3GCqjUitCP7N1pV0tKzc0xQJl11Dms0utLb9PJF2gllNW/5u7V5HtHFZKuiYLQNjJDvXG56v1Cyj5JeVf7Jip9oTtiytpMg3x2icFdQnwnQnZYujTW2EqRFrCIdpioQbgGi543J6fmb41bWvSLj7dQWBf7RxGRq+gcVUCiqJTKF7z9mpQMVPyS+/1l2DFDtB5luty2Vu+NrVRvUkbVX9zMvl259dETlyY/ZzYItIt0Q/cf76xiyJTEEod98wbdrmwcmTZ6ayHUELseKyjG9+iYwdL+PhB54MrQQlnkXytaONsKpyzuhkIpMnrhRc9J8xJsDIdO6p9trPRmdypPKPnqz6TowdHlcKt9124OhMjsSD/AvAart+2sHU++kWM7uwyMh0jk/++pebmcKXwJhX7n5jOhz3ITvjLkbPzv3St7mRnufWwwVkxY7ouAkKnlu+2jEp11aPJzqeK8nXShumP3148MI0x+LKOPA98LHD9SOrH0Y5B7yo+fj3dE/7ttLajlJQzwOHiu1s4VqtF5XD9LL2JxKz+LO0OeASsBPIOOnToGDKGnev5tQvffs9Z6c4M5X9G/iK4iv9omNHdNwEAc8tX/2Y6NuK0l5Q+Vpo4/HNwODwsmtENTmsrom5xDU7YoLxRGNe9dinQcGUNe6ei26Hfunb7PIhdkTHTRDw3PK1ahvzIZ4ryddPbSzZki3Zki2ZDPsPThY0NEA8GngAAAAASUVORK5CYII=" /></h3>
+        <p>The Chuck Norris app is also on <a href="http://m.me/chucknorris.io" rel="nofollow" target="_blank">Facebook Messenger</a>. Click the Message Us button below to start a conversation.</p>
         <p>You can simply ask a random joke by typing <code class="quoted red">hi, tell me a joke</code>. To get help to get started type <code class="quoted red">help</code>.</p>
-        <div class="fb-messengermessageus"
-          messenger_app_id="{{ facebook_messenger_app_id }}"
-          page_id="{{ facebook_messenger_page_id }}"
-          color="white"
-          size="standard" >
-        </div>
+        <div class="fb-messengermessageus" messenger_app_id="{{ facebook_app_id }}" page_id="{{ facebook_app_page_id }}" color="white" size="xlarge">
     </section>
     <section>
         <p><small><b>Contact:</b> Feel free to tweet ideas, suggestions, help requests and similar to <a href="https://twitter.com/MatChilling" target="_blank">@matchilling</a> or drop me a line at m@matchilling.com</small></p>
@@ -63,9 +58,10 @@
     <script>
     window.fbAsyncInit = function() {
       FB.init({
-        appId: "{{ facebook_messenger_app_id }}",
-        xfbml: true,
-        version: "{{ facebook_messenger_version }}"
+        appId   : "{{ facebook_app_id }}",
+        status  : true,
+        xfbml   : true,
+        version : "{{ facebook_jssdk_version }}"
       });
     };
 

--- a/assets/views/index.html
+++ b/assets/views/index.html
@@ -43,10 +43,40 @@
         </a>
         <p><small>Installation takes just 1 minute!</small></p>
         <p><small><b>Help:</b> From within slack, you can just type <code class="quoted red">/chuck help</code> for some extra information on how to use the app.</small></p>
+    </section>
+    <section id="facebook_messenger">
+        <h3><img alt="Facebook Messenger" src="" /></h3>
+        <p>The Chuck Norris app is also on Facebook Messenger. Click the Message Us button below to start a conversation.</p>
+        <p>You can simply ask a random joke by typing <code class="quoted red">hi, tell me a joke</code>. To get help to get started type <code class="quoted red">help</code>.</p>
+        <div class="fb-messengermessageus"
+          messenger_app_id="{{ facebook_messenger_app_id }}"
+          page_id="{{ facebook_messenger_page_id }}"
+          color="white"
+          size="standard" >
+        </div>
+    </section>
+    <section>
         <p><small><b>Contact:</b> Feel free to tweet ideas, suggestions, help requests and similar to <a href="https://twitter.com/MatChilling" target="_blank">@matchilling</a> or drop me a line at m@matchilling.com</small></p>
         <p><small><b>Privacy:</b> The app was a weekend project and is just fun. All we're storing are team and user ids and the appropriate OAuth tokens. This allows you to post these awesome Chuck Norris facts on slack on the appropriate channel. Our applications is hosted on https://aws.amazon.com/privacy. We use a secure connection between slack servers and aws. We anonymously keep track of two data points; the total number of teams and unique users. None of the data will ever be shared, except for maybe some anonymous statistics in the future.</small></p>
-
     </section>
+
+    <script>
+    window.fbAsyncInit = function() {
+      FB.init({
+        appId: "{{ facebook_messenger_app_id }}",
+        xfbml: true,
+        version: "{{ facebook_messenger_version }}"
+      });
+    };
+
+    (function(d, s, id){
+       var js, fjs = d.getElementsByTagName(s)[0];
+       if (d.getElementById(id)) { return; }
+       js = d.createElement(s); js.id = id;
+       js.src = "//connect.facebook.net/en_US/sdk.js";
+       fjs.parentNode.insertBefore(js, fjs);
+    }(document, 'script', 'facebook-jssdk'));
+    </script>
 
     <script>
     function toggleMe(target){

--- a/src/Api/Controller/IndexController.php
+++ b/src/Api/Controller/IndexController.php
@@ -32,17 +32,19 @@ class IndexController
         return $app['twig']->render(
             'index.html',
             [
-                'example_response_icon_url' => 'https://assets.chucknorris.host/img/avatar/chuck-norris.png',
-                'example_response_id'       => strval($joke->getId()),
-                'example_response_text'     => strval($joke->getValue()),
-                'example_response_url'      => $app['url_generator']->generate(
+                'example_response_icon_url'  => 'https://assets.chucknorris.host/img/avatar/chuck-norris.png',
+                'example_response_id'        => strval($joke->getId()),
+                'example_response_text'      => strval($joke->getValue()),
+                'example_response_url'       => $app['url_generator']->generate(
                     'api.get_joke',
                     [ 'id' => $joke->getId() ],
                     \Symfony\Component\Routing\Generator\UrlGenerator::ABSOLUTE_URL
                 ),
-                'slack_url'                 => \Chuck\App\Api\Controller\Connect\SlackController::getAuthUrl(
+                'slack_url'                  => \Chuck\App\Api\Controller\Connect\SlackController::getAuthUrl(
                     $app['url_generator']
-                )
+                ),
+                'facebook_messenger_app_id'  => '649210331916830',
+                'facebook_messenger_page_id' => '271921996156822'
             ]
         );
     }

--- a/src/Api/Controller/IndexController.php
+++ b/src/Api/Controller/IndexController.php
@@ -1,12 +1,20 @@
 <?php
-
 /**
  * IndexController.php - created Mar 6, 2016 3:03:18 PM
  *
- * @copyright Copyright (c) pinkbigmacmedia
+ * @copyright Copyright (c) Mathias Schilling <m@matchilling>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  *
  */
 namespace Chuck\App\Api\Controller;
+
+use \Chuck\App\Api\Exception\ConfigException as ConfigException;
+use \Silex\Application as App;
+use \Symfony\Component\HttpFoundation;
+use \Symfony\Component\HttpKernel\Exception;
+use \Symfony\Component\Routing\Generator\UrlGenerator as UrlGenerator;
 
 /**
  *
@@ -19,15 +27,31 @@ class IndexController
 {
     /**
      *
-     * @param  \Silex\Application                        $app
-     * @param  \Symfony\Component\HttpFoundation\Request $request
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @param  App                    $app
+     * @param  HttpFoundation\Request $request
+     * @throws ConfigException
+     * @throws Exception\NotFoundHttpException
      */
-    public function indexAction(
-        \Silex\Application $app,
-        \Symfony\Component\HttpFoundation\Request $request
-    ) {
-        $joke = $app['chuck.joke']->random();
+    public function indexAction(App $app, HttpFoundation\Request $request)
+    {
+        if (! $app['config']['facebook_app_id']) {
+            throw new ConfigException('FACEBOOK_APP_ID');
+        }
+
+        if (! $app['config']['facebook_app_page_id']) {
+            throw new ConfigException('FACEBOOK_APP_PAGE_ID');
+        }
+
+        if (! $app['config']['facebook_jssdk_version']) {
+            throw new ConfigException('FACEBOOK_JSSDK_VERSION');
+        }
+
+        if (! ($joke = $app['chuck.joke']->random()) instanceof \Chuck\Entity\Joke) {
+            throw new Exception\NotFoundHttpException('Could not retrieve random joke.');
+        }
+
+        /* @var UrlGenerator $urlGenerator */
+        $urlGenerator = $app['url_generator'];
 
         return $app['twig']->render(
             'index.html',
@@ -35,16 +59,15 @@ class IndexController
                 'example_response_icon_url'  => 'https://assets.chucknorris.host/img/avatar/chuck-norris.png',
                 'example_response_id'        => strval($joke->getId()),
                 'example_response_text'      => strval($joke->getValue()),
-                'example_response_url'       => $app['url_generator']->generate(
+                'example_response_url'       => $urlGenerator->generate(
                     'api.get_joke',
                     [ 'id' => $joke->getId() ],
-                    \Symfony\Component\Routing\Generator\UrlGenerator::ABSOLUTE_URL
+                    UrlGenerator::ABSOLUTE_URL
                 ),
-                'slack_url'                  => \Chuck\App\Api\Controller\Connect\SlackController::getAuthUrl(
-                    $app['url_generator']
-                ),
-                'facebook_messenger_app_id'  => '649210331916830',
-                'facebook_messenger_page_id' => '271921996156822'
+                'slack_url'                  => Connect\SlackController::getAuthUrl($urlGenerator),
+                'facebook_app_id'            => $app['config']['facebook_app_id'],
+                'facebook_app_page_id'       => $app['config']['facebook_app_page_id'],
+                'facebook_jssdk_version'     => $app['config']['facebook_jssdk_version']
             ]
         );
     }

--- a/src/Api/Exception/ConfigException.php
+++ b/src/Api/Exception/ConfigException.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * ConfigException.php - created 23 Oct 2016 10:28:25
+ *
+ * @copyright Copyright (c) Mathias Schilling <m@matchilling>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+namespace Chuck\App\Api\Exception;
+
+use \Symfony\Component\HttpKernel\Exception as Exception;
+
+/**
+ *
+ * ConfigException
+ *
+ * @package Chuck\App\Api
+ *
+ */
+class ConfigException extends Exception\HttpException
+{
+    /**
+     *
+     * @param string     $configId The configuration identifier
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     */
+    public function __construct($configId, \Exception $previous = null, $code = 0)
+    {
+        parent::__construct(
+            500,
+            sprintf('No value for "%s" specified.', $configId),
+            $previous = null,
+            [],
+            $code
+        );
+    }
+}

--- a/src/Api/ServicesLoader.php
+++ b/src/Api/ServicesLoader.php
@@ -1,9 +1,12 @@
 <?php
 
 /**
- * ServicesLoader.php - created Mar 6, 2016 3:03:18 PM
+ * ServicesLoader.php - created 23 Oct 2016 10:28:25
  *
- * @copyright Copyright (c) pinkbigmacmedia
+ * @copyright Copyright (c) Mathias Schilling <m@matchilling>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  *
  */
 namespace Chuck\App\Api;
@@ -68,8 +71,10 @@ class ServicesLoader implements \Silex\ServiceProviderInterface
                     'blackfire_server_token'      => getenv('BLACKFIRE_SERVER_TOKEN')      ? : null,
                     'database_url'                => getenv('DATABASE_URL')                ? : null,
                     'facebook_app_id'             => getenv('FACEBOOK_APP_ID')             ? : null,
+                    'facebook_app_page_id'        => getenv('FACEBOOK_APP_PAGE_ID')        ? : null,
                     'facebook_app_secret'         => getenv('FACEBOOK_APP_SECRET')         ? : null,
-                    'facebook_page_access_token'  => getenv('FACEBOOK_PAGE_ACCESS_TOKEN') ? : null,
+                    'facebook_jssdk_version'      => getenv('FACEBOOK_JSSDK_VERSION')      ? : null,
+                    'facebook_page_access_token'  => getenv('FACEBOOK_PAGE_ACCESS_TOKEN')  ? : null,
                     'facebook_verification_token' => getenv('FACEBOOK_VERIFICATION_TOKEN') ? : null,
                     'logzio_api_key'              => getenv('LOGZIO_API_KEY')              ? : null,
                     'mongodb_uri'                 => getenv('MONGODB_URI')                 ? : null,


### PR DESCRIPTION
@marceloverdijk I've appended your previous pull request and added the image for the `h3`.

I'm not quite sure though if the additional http call just for the button is necessary. I think a graphic with a link to `http://m.me/chucknorris.io` would do the job as well, or are they any other benefits which I've not spotted yet? Also the privacy aspect is worth thinking about. But we can change that in a further version anyway.

*Also if you don't mind I would like to ask you to use present tense in your commit msg.*
